### PR TITLE
Static analysis - core MP

### DIFF
--- a/mediapipe/framework/deps/file_helpers.cc
+++ b/mediapipe/framework/deps/file_helpers.cc
@@ -151,6 +151,7 @@ absl::Status GetContents(absl::string_view file_name, std::string* output,
     char buf[4096];
     size_t ret = fread(buf, 1, 4096, fp);
     if (ret == 0 && ferror(fp)) {
+      fclose(fp);
       return mediapipe::InternalErrorBuilder(MEDIAPIPE_LOC)
              << "Error while reading file: " << file_name;
     }

--- a/mediapipe/util/tflite/operations/max_pool_argmax.cc
+++ b/mediapipe/util/tflite/operations/max_pool_argmax.cc
@@ -156,6 +156,7 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   output_size->data[3] = channels_out;
   TfLiteIntArray* indices_size = TfLiteIntArrayCopy(output_size);
   if (context->ResizeTensor(context, output, output_size) != kTfLiteOk) {
+    TfLiteIntArrayFree(indices_size);
     return kTfLiteError;
   }
   if (context->ResizeTensor(context, indices, indices_size) != kTfLiteOk) {


### PR DESCRIPTION
- close file upon an error while reading
- deallocate TfLiteIntArray in case of errors