### PR TITLE
Add Model API as a full-fledged library

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -641,7 +641,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "ovms",
     remote = "https://github.com/openvinotoolkit/model_server",
-    commit = "25dcb5273bcf656c81e21fd56767b1535079b6b4", # branch with fix:  Move to ovms_dependencies
+    commit = "557eb3300b399bf52d02c0f596be3d832e3535ef", # branch with fix:  Move to ovms_dependencies
 )
 
 # DEV ovms - adjust local repository path for build

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -71,16 +71,24 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_cc/archive/2f8c04c04462ab83c545ab14c0da68c3b4c96191.zip"],
 )
 
-http_archive(
+#http_archive(
+#    name = "rules_foreign_cc",
+#    sha256 = "2a4d07cd64b0719b39a7c12218a3e507672b82a97b98c6a89d38565894cf7c51",
+#    strip_prefix = "rules_foreign_cc-0.9.0",
+#    url = "https://github.com/bazelbuild/rules_foreign_cc/archive/refs/tags/0.9.0.tar.gz",
+#)
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+git_repository( # Using commit past 0.9.0 that adds cmake 3.26.2 for model api. Be sure to update to 0.10.0 when available.
     name = "rules_foreign_cc",
-    sha256 = "2a4d07cd64b0719b39a7c12218a3e507672b82a97b98c6a89d38565894cf7c51",
-    strip_prefix = "rules_foreign_cc-0.9.0",
-    url = "https://github.com/bazelbuild/rules_foreign_cc/archive/refs/tags/0.9.0.tar.gz",
+    remote = "https://github.com/bazelbuild/rules_foreign_cc.git",
+    commit = "1fb8a1e",
+ #   strip_prefix = "rules_foreign_cc-0.9.0",
 )
 
 load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 
-rules_foreign_cc_dependencies()
+rules_foreign_cc_dependencies(cmake_version="3.26.2")
 
 http_archive(
     name = "com_google_protobuf",
@@ -636,8 +644,6 @@ http_archive(
     build_file = "@//third_party:halide.BUILD",
 )
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-
 git_repository(
     name = "ovms",
     remote = "https://github.com/openvinotoolkit/model_server",
@@ -834,17 +840,11 @@ git_repository(
     patches = ["@ovms//external:mwaitpkg.patch",]
 )
 
+load("@rules_foreign_cc//foreign_cc:cmake.bzl", "cmake")
+
 new_git_repository(
     name = "model_api",
     remote = "https:///github.com/openvinotoolkit/model_api/",
-    build_file_content = """
-cc_library(
-    name = "adapter_api",
-    hdrs = ["model_api/cpp/adapters/include/adapters/inference_adapter.h",],
-    includes = ["model_api/cpp/adapters/include"],
-    deps = ["@linux_openvino//:openvino"],
-    visibility = ["//visibility:public"],
-)
-    """,
-    commit = "ca5a91ed5b3dbf428dc4de6b72f0a3da93d2aa0a"
+    build_file = "@//third_party/model_api:BUILD",
+    commit = "03a6cee5d486ee9eabb625e4388e69fe9c50ef20"
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -641,7 +641,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "ovms",
     remote = "https://github.com/openvinotoolkit/model_server",
-    commit = "557eb3300b399bf52d02c0f596be3d832e3535ef", # branch with fix:  Move to ovms_dependencies
+    commit = "77cae866bfa9eaa96b65704a9613cfca21842dd5", # branch with fix:  Move to ovms_dependencies
 )
 
 # DEV ovms - adjust local repository path for build

--- a/third_party/model_api/BUILD
+++ b/third_party/model_api/BUILD
@@ -1,0 +1,53 @@
+load("@rules_foreign_cc//foreign_cc:cmake.bzl", "cmake")
+
+_ALL_CONTENT = """\
+filegroup(
+    name = "all_srcs",
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)
+"""
+
+
+
+visibility = ["//visibility:public"]
+
+filegroup(
+    name = "all_srcs",
+    srcs = glob(["model_api/cpp/**"]),
+    visibility = ["//visibility:public"],
+)
+
+cmake(
+    name = "model_api_cmake",
+    cache_entries = {
+        "CMAKE_POSITION_INDEPENDENT_CODE": "ON",
+        "OpenVINO_DIR": "/opt/intel/openvino/runtime/cmake",
+    },
+    env = {
+        "HTTP_PROXY": "http://proxy-dmz.intel.com:911",
+        "HTTPS_PROXY": "http://proxy-dmz.intel.com:912",
+    },
+    #lib_source = "@model_api_geti//:all_srcs",
+    lib_source = ":all_srcs",
+    out_static_libs = ["libmodel_api.a"],
+    tags = ["requires-network"]
+)
+
+cc_library(
+    name = "model_api",
+    deps = [
+        "@mediapipe//mediapipe/framework/port:opencv_core",
+        "@linux_openvino//:openvino",
+        ":model_api_cmake",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+   name = "adapter_api",
+   hdrs = ["model_api/cpp/adapters/include/adapters/inference_adapter.h",],
+   includes = ["model_api/cpp/adapters/include"],
+   deps = ["@linux_openvino//:openvino"],
+   visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
* Updated bazel rules_foreign to commit past 0.9
This is required to be able to use cmake >= 3.262 required for Model API

JIRA:CVS-120866