### PR TITLE
Geti calculator updates

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -840,7 +840,7 @@ new_git_repository(
     name = "model_api",
     remote = "https:///github.com/openvinotoolkit/model_api/",
     build_file = "@_model-api//:BUILD",
-    commit = "0ba6bee38fb77484c559d65d654b05b267f9f35c"
+    commit = "9022adeb26ac0e5afe9814afa260fd208d09383a"
 )
 
 git_repository(

--- a/mediapipe/calculators/geti/examples/BUILD
+++ b/mediapipe/calculators/geti/examples/BUILD
@@ -25,8 +25,8 @@ cc_library(
 )
 
 cc_binary(
-    name = "anomaly_calculator_demo",
-    srcs = ["anomaly_calculator_demo.cc"],
+    name = "calculator_demo",
+    srcs = ["calculator_demo.cc"],
     data = [
         "//mediapipe/calculators/geti/graphs:graphs",
     ],

--- a/mediapipe/calculators/geti/examples/calculator_demo.cc
+++ b/mediapipe/calculators/geti/examples/calculator_demo.cc
@@ -1,19 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- *
- */
 #include <cstdlib>
 #include <memory>
 #include <opencv2/core.hpp>

--- a/mediapipe/calculators/geti/examples/calculator_demo.cc
+++ b/mediapipe/calculators/geti/examples/calculator_demo.cc
@@ -30,10 +30,10 @@ ABSL_FLAG(std::string, output_image_path, "/data/mp_dep_output.jpg",
           "Full path of where to save image result (.jpg only). "
           "If not provided, show result in a window.");
 ABSL_FLAG(std::string, graph_config_path,
-          "mediapipe/calculators/geti/graphs/examples/mapi_anomaly_calculator.pbtxt",
+          "mediapipe/calculators/geti/graphs/examples/mapi_instance_segmentation_calculator.pbtxt",
           "Full path to the graph description file.");
 ABSL_FLAG(std::string, model_xml_path,
-          "/data/geti/anomaly_classification_padim.xml",
+          "/data/geti/instance_segmentation_maskrcnn_resnet50.xml",
           "Full path to the model xml file.");
 
 namespace {

--- a/mediapipe/calculators/geti/inference/BUILD
+++ b/mediapipe/calculators/geti/inference/BUILD
@@ -66,6 +66,7 @@ cc_library(
         "//mediapipe/framework/port:opencv_imgcodecs",
         "//mediapipe/framework/port:opencv_imgproc",
         "//mediapipe/calculators/geti/utils:data_structures",
+        "//mediapipe/calculators/geti/utils:contourer",
         "//mediapipe/calculators/geti/utils:emptylabel_cc_proto",
         ":inference_utils",
         "@model_api//:model_api",

--- a/mediapipe/calculators/geti/inference/anomaly_calculator.h
+++ b/mediapipe/calculators/geti/inference/anomaly_calculator.h
@@ -1,18 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
 #ifndef ANOMALY_CALCULATOR_H
 #define ANOMALY_CALCULATOR_H
 

--- a/mediapipe/calculators/geti/inference/anomaly_calculator.h
+++ b/mediapipe/calculators/geti/inference/anomaly_calculator.h
@@ -29,11 +29,11 @@ namespace mediapipe {
 //  INFERENCE_ADAPTER
 //
 
-class AnomalyCalculator : public CalculatorBase {
+class AnomalyCalculator : public GetiCalculatorBase {
  public:
   static absl::Status GetContract(CalculatorContract *cc);
   absl::Status Open(CalculatorContext *cc) override;
-  absl::Status Process(CalculatorContext *cc) override;
+  absl::Status GetiProcess(CalculatorContext *cc) override;
   absl::Status Close(CalculatorContext *cc) override;
 
  private:

--- a/mediapipe/calculators/geti/inference/anomaly_calculator_test.cc
+++ b/mediapipe/calculators/geti/inference/anomaly_calculator_test.cc
@@ -1,19 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
-
 #include "anomaly_calculator.h"
 
 #include <map>

--- a/mediapipe/calculators/geti/inference/classification_calculator.cc
+++ b/mediapipe/calculators/geti/inference/classification_calculator.cc
@@ -1,19 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- *
- */
 #include "classification_calculator.h"
 
 #include <memory>

--- a/mediapipe/calculators/geti/inference/classification_calculator.h
+++ b/mediapipe/calculators/geti/inference/classification_calculator.h
@@ -1,18 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
 #ifndef CLASSIFICATION_CALCULATOR_H
 #define CLASSIFICATION_CALCULATOR_H
 
@@ -40,7 +25,7 @@ namespace mediapipe {
 //  IMAGE - cv::Mat
 //
 // Output:
-//  CLASSIFICATION - ClassificationResult
+//  CLASSIFICATION - InferenceResult
 //
 // Input side packet:
 //  INFERENCE_ADAPTER - std::shared_ptr<InferenceAdapter>

--- a/mediapipe/calculators/geti/inference/classification_calculator_test.cc
+++ b/mediapipe/calculators/geti/inference/classification_calculator_test.cc
@@ -1,19 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
-
 #include "classification_calculator.h"
 
 #include <map>

--- a/mediapipe/calculators/geti/inference/detection_calculator.cc
+++ b/mediapipe/calculators/geti/inference/detection_calculator.cc
@@ -1,19 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
-
 #include "detection_calculator.h"
 
 #include <memory>

--- a/mediapipe/calculators/geti/inference/detection_calculator.h
+++ b/mediapipe/calculators/geti/inference/detection_calculator.h
@@ -1,18 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
 #ifndef DETECTION_CALCULATOR_H
 #define DETECTION_CALCULATOR_H
 
@@ -39,7 +24,7 @@ namespace mediapipe {
 //  IMAGE - cv::Mat
 //
 // Output:
-//  DETECTIONS - DetectionResult
+//  DETECTIONS - InferenceResult
 //
 // Input side packet:
 //  INFERENCE_ADAPTER - std::shared_ptr<InferenceAdapter>

--- a/mediapipe/calculators/geti/inference/detection_calculator_test.cc
+++ b/mediapipe/calculators/geti/inference/detection_calculator_test.cc
@@ -1,19 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
-
 #include "detection_calculator.h"
 
 #include <map>

--- a/mediapipe/calculators/geti/inference/geti_calculator_base.h
+++ b/mediapipe/calculators/geti/inference/geti_calculator_base.h
@@ -1,18 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
 #ifndef GETI_CALCULATOR_BASE_H
 #define GETI_CALCULATOR_BASE_H
 

--- a/mediapipe/calculators/geti/inference/instance_segmentation_calculator.cc
+++ b/mediapipe/calculators/geti/inference/instance_segmentation_calculator.cc
@@ -129,7 +129,6 @@ absl::Status InstanceSegmentationCalculator::Close(CalculatorContext *cc) {
   LOG(INFO) << "InstanceSegmentationCalculator::Close()";
   return absl::OkStatus();
 }
-
 REGISTER_CALCULATOR(InstanceSegmentationCalculator);
 
 }  // namespace mediapipe

--- a/mediapipe/calculators/geti/inference/instance_segmentation_calculator.h
+++ b/mediapipe/calculators/geti/inference/instance_segmentation_calculator.h
@@ -47,6 +47,7 @@ class InstanceSegmentationCalculator : public GetiCalculatorBase {
   bool use_ellipse_shapes = false;
 };
 
+
 }  // namespace mediapipe
 
 #endif  // INSTANCE_SEGMENTATION_CALCULATOR_H

--- a/mediapipe/calculators/geti/inference/instance_segmentation_calculator.h
+++ b/mediapipe/calculators/geti/inference/instance_segmentation_calculator.h
@@ -1,18 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
 #ifndef INSTANCE_SEGMENTATION_CALCULATOR_H
 #define INSTANCE_SEGMENTATION_CALCULATOR_H
 
@@ -40,7 +25,7 @@ namespace mediapipe {
 //  IMAGE - cv::Mat
 //
 // Output:
-//  RESULT - SegmentationResult
+//  RESULT - InferenceResult
 //
 // Input side packet:
 //  INFERENCE_ADAPTER - std::shared_ptr<InferenceAdapter>
@@ -58,6 +43,8 @@ class InstanceSegmentationCalculator : public GetiCalculatorBase {
   std::unique_ptr<MaskRCNNModel> model;
   std::unique_ptr<InstanceSegmentationTiler> tiler;
   std::vector<geti::Label> labels;
+
+  bool use_ellipse_shapes = false;
 };
 
 }  // namespace mediapipe

--- a/mediapipe/calculators/geti/inference/instance_segmentation_calculator_test.cc
+++ b/mediapipe/calculators/geti/inference/instance_segmentation_calculator_test.cc
@@ -1,19 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
-
 #include "instance_segmentation_calculator.h"
 
 #include <map>

--- a/mediapipe/calculators/geti/inference/kserve.h
+++ b/mediapipe/calculators/geti/inference/kserve.h
@@ -1,18 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
 #ifndef KSERVE_H
 #define KSERVE_H
 

--- a/mediapipe/calculators/geti/inference/model_infer_request_image_calculator.cc
+++ b/mediapipe/calculators/geti/inference/model_infer_request_image_calculator.cc
@@ -1,70 +1,75 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
-
 #include "model_infer_request_image_calculator.h"
 
 namespace mediapipe {
 
-    absl::Status ModelInferRequestImageCalculator::GetContract(
-            CalculatorContract *cc) {
-        LOG(INFO) << "ModelInferRequestImageCalculator::GetContract()";
-        cc->Inputs().Tag("REQUEST").Set<const KFSRequest *>();
-        cc->Outputs().Tag("IMAGE").Set<cv::Mat>();
+absl::Status ModelInferRequestImageCalculator::GetContract(
+        CalculatorContract *cc) {
+    LOG(INFO) << "ModelInferRequestImageCalculator::GetContract()";
+    cc->Inputs().Tag("REQUEST").Set<const KFSRequest *>();
+    cc->Outputs().Tag("IMAGE").Set<cv::Mat>();
 
-        return absl::OkStatus();
-    }
+    return absl::OkStatus();
+}
 
-    absl::Status ModelInferRequestImageCalculator::Open(CalculatorContext *cc) {
-        LOG(INFO) << "ModelInferRequestImageCalculator::Open()";
-        return absl::OkStatus();
-    }
+absl::Status ModelInferRequestImageCalculator::Open(CalculatorContext *cc) {
+    LOG(INFO) << "ModelInferRequestImageCalculator::Open()";
+    return absl::OkStatus();
+}
 
-    absl::Status ModelInferRequestImageCalculator::GetiProcess(
-            CalculatorContext *cc) {
-        LOG(INFO) << "ModelInferRequestImageCalculator::GetiProcess()";
-        const KFSRequest *request =
-                cc->Inputs().Tag("REQUEST").Get<const KFSRequest *>();
+absl::Status ModelInferRequestImageCalculator::GetiProcess(
+        CalculatorContext *cc) {
+    LOG(INFO) << "ModelInferRequestImageCalculator::GetiProcess()";
+    const KFSRequest *request =
+            cc->Inputs().Tag("REQUEST").Get<const KFSRequest *>();
 
-        LOG(INFO) << "KFSRequest for model " << request->model_name();
-        auto data = request->raw_input_contents().Get(0);
-        std::vector<char> image_data(data.begin(), data.end());
-        auto out = cv::imdecode(image_data, 1);
-        cv::cvtColor(out, out, cv::COLOR_BGR2RGB);
+    LOG(INFO) << "KFSRequest for model " << request->model_name();
+    auto data = request->raw_input_contents().Get(0);
+    std::vector<char> image_data(data.begin(), data.end());
+    auto out = load_image(image_data);
+    cv::cvtColor(out, out, cv::COLOR_BGR2RGB);
 
-        // crop ROI if its passed
-        if (request->parameters().find("width") != request->parameters().end()) {
-            auto roi_x = (int) request->parameters().at("x").int64_param();
-            auto roi_y = (int) request->parameters().at("y").int64_param();
-            auto roi_width = (int) request->parameters().at("width").int64_param();
-            auto roi_height = (int) request->parameters().at("height").int64_param();
-            if (roi_width > 0 && roi_height > 0) {
-                auto roi = cv::Rect(roi_x, roi_y, roi_width, roi_height);
-                out = out(roi).clone();
-            }
+    // crop ROI if its passed
+    if (request->parameters().find("width") != request->parameters().end()) {
+        auto roi_x = (int) request->parameters().at("x").int64_param();
+        auto roi_y = (int) request->parameters().at("y").int64_param();
+        auto roi_width = (int) request->parameters().at("width").int64_param();
+        auto roi_height = (int) request->parameters().at("height").int64_param();
+        if (roi_width > 0 && roi_height > 0) {
+            auto roi = cv::Rect(roi_x, roi_y, roi_width, roi_height);
+            out = out(roi).clone();
         }
-
-        cc->Outputs().Tag("IMAGE").AddPacket(MakePacket<cv::Mat>(out).At(cc->InputTimestamp()));
-        return absl::OkStatus();
     }
 
-    absl::Status ModelInferRequestImageCalculator::Close(CalculatorContext *cc) {
-        LOG(INFO) << "ModelInferRequestImageCalculator::Close()";
-        return absl::OkStatus();
-    }
+    cc->Outputs().Tag("IMAGE").AddPacket(MakePacket<cv::Mat>(out).At(cc->InputTimestamp()));
+    return absl::OkStatus();
+}
 
-    REGISTER_CALCULATOR(ModelInferRequestImageCalculator);
+absl::Status ModelInferRequestImageCalculator::Close(CalculatorContext *cc) {
+    LOG(INFO) << "ModelInferRequestImageCalculator::Close()";
+    return absl::OkStatus();
+}
+
+cv::Mat ModelInferRequestImageCalculator::load_image(const std::vector<char> &image_data) {
+  cv::Mat mat;
+  try {
+    mat = cv::imdecode(image_data, 1);
+  } catch (cv::Exception &e) {
+    std::string error = e.what();
+    if (error.find("CV_IO_MAX_IMAGE") == std::string::npos) {
+      throw;
+    } else {
+      throw std::runtime_error(OUT_OF_BOUNDS_ERROR);
+    }
+  }
+
+  if (mat.cols < MIN_SIZE || mat.rows < MIN_SIZE) {
+    throw std::runtime_error(OUT_OF_BOUNDS_ERROR);
+  }
+
+  return mat;
+}
+
+
+REGISTER_CALCULATOR(ModelInferRequestImageCalculator);
 
 }  // namespace mediapipe

--- a/mediapipe/calculators/geti/inference/model_infer_request_image_calculator.h
+++ b/mediapipe/calculators/geti/inference/model_infer_request_image_calculator.h
@@ -1,18 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
 #ifndef MODEL_INFER_REQUEST_IMAGE_CALCULATOR_H_
 #define MODEL_INFER_REQUEST_IMAGE_CALCULATOR_H_
 
@@ -40,11 +25,17 @@ namespace mediapipe {
 //
 
 class ModelInferRequestImageCalculator : public GetiCalculatorBase {
+ const size_t MIN_SIZE = 32;
+ const std::string OUT_OF_BOUNDS_ERROR = "IMAGE_SIZE_OUT_OF_BOUNDS";
+
  public:
   static absl::Status GetContract(CalculatorContract *cc);
   absl::Status Open(CalculatorContext *cc) override;
   absl::Status GetiProcess(CalculatorContext *cc) override;
   absl::Status Close(CalculatorContext *cc) override;
+
+ private:
+  cv::Mat load_image(const std::vector<char> &image_data);
 };
 
 }  // namespace mediapipe

--- a/mediapipe/calculators/geti/inference/model_infer_request_image_calculator_test.cc
+++ b/mediapipe/calculators/geti/inference/model_infer_request_image_calculator_test.cc
@@ -1,19 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
-
 #include <fstream>
 #include <map>
 #include <openvino/openvino.hpp>
@@ -37,6 +21,16 @@
 
 namespace mediapipe {
 
+  const auto graph_content = R"pb(
+            input_stream: "input"
+            output_stream: "output"
+            node {
+              calculator: "ModelInferRequestImageCalculator"
+              input_stream: "REQUEST:input"
+              output_stream: "IMAGE:output"
+            }
+          )pb";
+
 inference::ModelInferRequest build_request(std::string& file_path) {
   auto request = inference::ModelInferRequest();
   std::ifstream is(file_path);
@@ -52,15 +46,7 @@ TEST(ModelInferRequestImageCalculatorTest, ImageIsConvertedToCVMatrix) {
 
   CalculatorGraphConfig graph_config =
       ParseTextProtoOrDie<CalculatorGraphConfig>(absl::Substitute(
-          R"pb(
-            input_stream: "input"
-            output_stream: "output"
-            node {
-              calculator: "ModelInferRequestImageCalculator"
-              input_stream: "REQUEST:input"
-              output_stream: "IMAGE:output"
-            }
-          )pb"));
+          graph_content));
 
   const cv::Mat raw_image = cv::imread(file_path);
   auto request = build_request(file_path);
@@ -77,6 +63,81 @@ TEST(ModelInferRequestImageCalculatorTest, ImageIsConvertedToCVMatrix) {
   cv::cvtColor(raw_image, expected_image, cv::COLOR_BGR2RGB);
   bool image_is_identical = !cv::norm(image, expected_image, cv::NORM_L1);
   ASSERT_TRUE(image_is_identical);
+}
+
+TEST(ModelInferRequestImageCalculatorTest, ImageTooSmallThrowsError) {
+  testing::internal::CaptureStdout();
+  std::string file_path = "/data/pearl.jpg";
+
+  CalculatorGraphConfig graph_config =
+      ParseTextProtoOrDie<CalculatorGraphConfig>(absl::Substitute(
+          graph_content));
+
+  const cv::Mat raw_image = cv::imread(file_path);
+  cv::Mat too_small_image;
+  cv::resize(raw_image, too_small_image, cv::Size(25, 25));
+
+  std::vector<uchar> buffer;
+  cv::imencode(".jpg", too_small_image, buffer);
+
+  std::string image_data(buffer.begin(), buffer.end());
+
+  auto request = inference::ModelInferRequest();
+  request.mutable_raw_input_contents()->Add(std::move(image_data));
+  auto packet =
+      mediapipe::MakePacket<const inference::ModelInferRequest*>(&request);
+  std::vector<Packet> output_packets;
+  mediapipe::tool::AddVectorSink("output", &graph_config, &output_packets);
+
+  mediapipe::CalculatorGraph graph(graph_config);
+
+  MP_ASSERT_OK(graph.StartRun({}));
+  MP_ASSERT_OK(graph.AddPacketToInputStream(
+      "input", packet.At(mediapipe::Timestamp(0))));
+
+  auto status = graph.WaitUntilIdle();
+  ASSERT_FALSE(status.ok());
+  ASSERT_EQ(0, output_packets.size());
+  std::string output = testing::internal::GetCapturedStdout();
+  ASSERT_EQ(output, "Caught exception with message: IMAGE_SIZE_OUT_OF_BOUNDS\n");
+}
+
+TEST(ModelInferRequestImageCalculatorTest, ImageTooBigThrowsError) {
+  testing::internal::CaptureStdout();
+  std::string file_path = "/data/pearl.jpg";
+
+  CalculatorGraphConfig graph_config =
+      ParseTextProtoOrDie<CalculatorGraphConfig>(absl::Substitute(
+          graph_content));
+
+  const cv::Mat raw_image = cv::imread(file_path);
+  cv::Mat too_big_image;
+  cv::resize(raw_image, too_big_image, cv::Size(8000, 8000));
+
+  std::vector<uchar> buffer;
+  cv::imencode(".jpg", too_big_image, buffer);
+
+  std::string image_data(buffer.begin(), buffer.end());
+
+  auto request = inference::ModelInferRequest();
+  request.mutable_raw_input_contents()->Add(std::move(image_data));
+  auto packet =
+      mediapipe::MakePacket<const inference::ModelInferRequest*>(&request);
+  std::vector<Packet> output_packets;
+  mediapipe::tool::AddVectorSink("output", &graph_config, &output_packets);
+
+  mediapipe::CalculatorGraph graph(graph_config);
+
+  MP_ASSERT_OK(graph.StartRun({}));
+  MP_ASSERT_OK(graph.AddPacketToInputStream(
+      "input", packet.At(mediapipe::Timestamp(0))));
+
+  auto status = graph.WaitUntilIdle();
+  ASSERT_FALSE(status.ok());
+  ASSERT_EQ(0, output_packets.size());
+  std::string output = testing::internal::GetCapturedStdout();
+  ASSERT_EQ(output, "Caught exception with message: IMAGE_SIZE_OUT_OF_BOUNDS\n");
+
 }
 
 }  // namespace mediapipe

--- a/mediapipe/calculators/geti/inference/openvino_inference_adapter_calculator.cc
+++ b/mediapipe/calculators/geti/inference/openvino_inference_adapter_calculator.cc
@@ -1,18 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
 #include "openvino_inference_adapter_calculator.h"
 
 #include <adapters/openvino_adapter.h>

--- a/mediapipe/calculators/geti/inference/openvino_inference_adapter_calculator.h
+++ b/mediapipe/calculators/geti/inference/openvino_inference_adapter_calculator.h
@@ -1,18 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
 #ifndef OPENVINO_INFERENCE_ADAPTER_CALCULATOR_H
 #define OPENVINO_INFERENCE_ADAPTER_CALCULATOR_H
 #include <adapters/inference_adapter.h>

--- a/mediapipe/calculators/geti/inference/rotated_detection_calculator.cc
+++ b/mediapipe/calculators/geti/inference/rotated_detection_calculator.cc
@@ -1,19 +1,3 @@
-/*
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
-
 #include "rotated_detection_calculator.h"
 
 #include <memory>

--- a/mediapipe/calculators/geti/inference/rotated_detection_calculator.h
+++ b/mediapipe/calculators/geti/inference/rotated_detection_calculator.h
@@ -1,18 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
 #ifndef ROTATED_DETECTION_CALCULATOR_H_
 #define ROTATED_DETECTION_CALCULATOR_H_
 
@@ -39,7 +24,7 @@ namespace mediapipe {
 //  IMAGE - cv::Mat
 //
 // Output:
-//  DETECTIONS - RotatedDetectionResult
+//  DETECTIONS - InferenceResult
 //
 // Input side packet:
 //  INFERENCE_ADAPTER - std::shared_ptr<InferenceAdapter>

--- a/mediapipe/calculators/geti/inference/rotated_detection_calculator_test.cc
+++ b/mediapipe/calculators/geti/inference/rotated_detection_calculator_test.cc
@@ -1,19 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
-
 #include <map>
 #include <string>
 #include <vector>

--- a/mediapipe/calculators/geti/inference/segmentation_calculator.cc
+++ b/mediapipe/calculators/geti/inference/segmentation_calculator.cc
@@ -1,19 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
-
 #include "segmentation_calculator.h"
 
 #include <memory>

--- a/mediapipe/calculators/geti/inference/segmentation_calculator.h
+++ b/mediapipe/calculators/geti/inference/segmentation_calculator.h
@@ -1,18 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
 #ifndef SEGMENTATION_CALCULATOR_H
 #define SEGMENTATION_CALCULATOR_H
 

--- a/mediapipe/calculators/geti/inference/segmentation_calculator_test.cc
+++ b/mediapipe/calculators/geti/inference/segmentation_calculator_test.cc
@@ -1,19 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
-
 #include "segmentation_calculator.h"
 
 #include <map>

--- a/mediapipe/calculators/geti/inference/test_utils.h
+++ b/mediapipe/calculators/geti/inference/test_utils.h
@@ -1,19 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
-
 #ifndef TEST_UTILS_H_
 #define TEST_UTILS_H_
 

--- a/mediapipe/calculators/geti/inference/utils.cc
+++ b/mediapipe/calculators/geti/inference/utils.cc
@@ -1,19 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
-
 #include "utils.h"
 
 namespace geti {

--- a/mediapipe/calculators/geti/serialization/serialization_calculators.cc
+++ b/mediapipe/calculators/geti/serialization/serialization_calculators.cc
@@ -1,19 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
-
 #include "serialization_calculators.h"
 
 #include <nlohmann/json_fwd.hpp>

--- a/mediapipe/calculators/geti/serialization/serialization_calculators.h
+++ b/mediapipe/calculators/geti/serialization/serialization_calculators.h
@@ -1,18 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
 #ifndef SERIALIZATION_CALCULATOR_H_
 #define SERIALIZATION_CALCULATOR_H_
 

--- a/mediapipe/calculators/geti/serialization/serialization_calculators_test.cc
+++ b/mediapipe/calculators/geti/serialization/serialization_calculators_test.cc
@@ -1,19 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
-
 #include <filesystem>
 #include <fstream>
 #include <map>

--- a/mediapipe/calculators/geti/utils/BUILD
+++ b/mediapipe/calculators/geti/utils/BUILD
@@ -13,7 +13,8 @@ cc_library(
         ":overlay_calculator",
         ":detection_extraction_calculator",
         ":combiner_calculators",
-        ":emptylabel_calculators"
+        ":emptylabel_calculators",
+        ":contourer",
     ],
     alwayslink = 1,
 )
@@ -25,6 +26,20 @@ cc_library(
     ],
     deps = [
         "@model_api//:model_api",
+    ]
+)
+
+cc_library(
+    name = "contourer",
+    hdrs = [
+        "contourer.h",
+    ],
+    srcs = [
+        "contourer.cc",
+    ],
+    deps = [
+        "@model_api//:model_api",
+        ":data_structures",
     ]
 )
 

--- a/mediapipe/calculators/geti/utils/contourer.cc
+++ b/mediapipe/calculators/geti/utils/contourer.cc
@@ -1,0 +1,120 @@
+#include "contourer.h"
+
+namespace geti {
+
+// Threshold for switching between single and multi processing
+// Experimentally the threshold for faster multi threading was found at 50 instances
+size_t Contourer::INSTANCE_THRESHOLD = 50;
+
+void Contourer::process() {
+  start();
+  while (busy()) {
+    std::this_thread::sleep_for(std::chrono::microseconds(10));
+  }
+  stop();
+}
+
+void Contourer::start() {
+  for (uint32_t ii = 0; ii < num_threads; ++ii) {
+    threads.emplace_back(std::thread(&Contourer::thread_loop, this));
+  }
+}
+
+void Contourer::queue(const std::vector<SegmentedObject> &objects) {
+  {
+    std::unique_lock<std::mutex> lock(queue_mutex);
+    for (auto &obj : objects) {
+      jobs.push(obj);
+    }
+  }
+  queue_condition.notify_one();
+}
+
+void Contourer::stop() {
+  {
+    std::unique_lock<std::mutex> lock(queue_mutex);
+    should_terminate = true;
+  }
+  queue_condition.notify_all();
+  for (std::thread &active_thread : threads) {
+    active_thread.join();
+  }
+  threads.clear();
+}
+
+bool Contourer::busy() {
+  bool poolbusy;
+  {
+    std::unique_lock<std::mutex> lock(queue_mutex);
+    poolbusy = !jobs.empty();
+  }
+  return poolbusy;
+}
+void Contourer::contour(const SegmentedObject &object) {
+  std::vector<std::vector<cv::Point>> contours;
+  cv::Mat mask;
+  object.mask.convertTo(mask, CV_8U);
+  cv::resize(mask, mask, object.size());
+  cv::findContours(mask, contours, cv::RETR_EXTERNAL, cv::CHAIN_APPROX_NONE);
+
+  if (contours.size() > 0) {
+    double biggest_area = 0.0;
+    std::vector<cv::Point> biggest_contour, approxCurve;
+    for (auto contour : contours) {
+      double area = cv::contourArea(contour);
+      if (biggest_area < area) {
+        biggest_area = area;
+        biggest_contour = contour;
+      }
+    }
+
+    if (biggest_contour.size() > 0) {
+      cv::approxPolyDP(biggest_contour, approxCurve, 1.0f, true);
+      if (approxCurve.size() > 2) {
+        position_contour(approxCurve, mask.size(), object);
+
+        store({{geti::LabelResult{object.confidence, labels[object.labelID]}},
+               approxCurve});
+      }
+    }
+  }
+}
+
+void Contourer::position_contour(std::vector<cv::Point> &contour,
+                                 const cv::Size &mask_size,
+                                 const cv::Rect &obj) {
+  cv::Point2f scale(float(obj.size().width) / mask_size.width,
+                    float(obj.size().height) / mask_size.height);
+  for (auto &point : contour) {
+    point.x = point.x + obj.x;
+    point.y = point.y + obj.y;
+  }
+}
+
+void Contourer::thread_loop() {
+  while (true) {
+    SegmentedObject obj;
+    bool has_job = false;
+    {
+      std::unique_lock<std::mutex> lock(queue_mutex);
+      queue_condition.wait(
+          lock, [this] { return !jobs.empty() || should_terminate; });
+      if (should_terminate) {
+        return;
+      }
+
+      obj = jobs.front();
+      jobs.pop();
+    }
+    contour(obj);
+  }
+}
+
+void Contourer::store(const PolygonPrediction &prediction) {
+  {
+    std::unique_lock<std::mutex> lock(store_mutex);
+    contours.push_back(prediction);
+  }
+}
+
+}  // namespace geti

--- a/mediapipe/calculators/geti/utils/contourer.h
+++ b/mediapipe/calculators/geti/utils/contourer.h
@@ -14,6 +14,15 @@
 
 namespace geti {
 
+
+
+inline cv::Rect expand_box(const cv::Rect2f& box, float scale) {
+    float w_half = box.width * 0.5f * scale,
+        h_half = box.height * 0.5f * scale;
+    const cv::Point2f& center = (box.tl() + box.br()) * 0.5f;
+    return {cv::Point(int(center.x - w_half), int(center.y - h_half)), cv::Point(int(center.x + w_half), int(center.y + h_half))};
+}
+
 class Contourer {
  private:
   std::mutex queue_mutex;
@@ -46,6 +55,9 @@ class Contourer {
                         const cv::Size &mask_size, const cv::Rect &obj);
   void thread_loop();
   void store(const PolygonPrediction &prediction);
+
+  cv::Mat resize(const SegmentedObject& box, const cv::Mat& unpadded, const cv::Rect& area);
+
 };
 
 }  // namespace geti

--- a/mediapipe/calculators/geti/utils/contourer.h
+++ b/mediapipe/calculators/geti/utils/contourer.h
@@ -1,0 +1,54 @@
+#ifndef CONTOURER_H
+#define CONTOURER_H
+
+#include <models/results.h>
+
+#include <condition_variable>
+#include <iostream>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <vector>
+
+#include "data_structures.h"
+
+namespace geti {
+
+class Contourer {
+ private:
+  std::mutex queue_mutex;
+  std::condition_variable queue_condition;
+  std::mutex store_mutex;
+
+  std::queue<SegmentedObject> jobs;
+  std::vector<geti::Label> labels;
+
+  std::vector<std::thread> threads;
+  bool should_terminate = false;
+
+ protected:
+  const uint32_t num_threads;
+
+ public:
+  std::vector<PolygonPrediction> contours;
+  Contourer(std::vector<geti::Label> labels)
+    : num_threads(std::thread::hardware_concurrency()), labels(labels) {}
+
+  static size_t INSTANCE_THRESHOLD;
+
+  void process();
+  void start();
+  void queue(const std::vector<SegmentedObject> &objects);
+  void stop();
+  bool busy();
+  void contour(const SegmentedObject &object);
+  void position_contour(std::vector<cv::Point> &contour,
+                        const cv::Size &mask_size, const cv::Rect &obj);
+  void thread_loop();
+  void store(const PolygonPrediction &prediction);
+};
+
+}  // namespace geti
+
+
+#endif // CONTOURER_H

--- a/mediapipe/calculators/geti/utils/crop_calculator.cc
+++ b/mediapipe/calculators/geti/utils/crop_calculator.cc
@@ -1,18 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
 #include "crop_calculator.h"
 
 #include <memory>

--- a/mediapipe/calculators/geti/utils/crop_calculator.h
+++ b/mediapipe/calculators/geti/utils/crop_calculator.h
@@ -1,18 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
 #ifndef CROP_CALCULATOR_H
 #define CROP_CALCULATOR_H
 

--- a/mediapipe/calculators/geti/utils/crop_calculator_test.cc
+++ b/mediapipe/calculators/geti/utils/crop_calculator_test.cc
@@ -1,19 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
-
 #include "crop_calculator.h"
 
 #include <vector>

--- a/mediapipe/calculators/geti/utils/data_structures.h
+++ b/mediapipe/calculators/geti/utils/data_structures.h
@@ -1,18 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
 #ifndef DATA_STRUCTURES_H
 #define DATA_STRUCTURES_H
 
@@ -52,11 +37,23 @@ struct RotatedRectanglePrediction {
   cv::RotatedRect shape;
 };
 
+struct Circle {
+  float x;
+  float y;
+  float radius;
+};
+
+struct CirclePrediction {
+  std::vector<LabelResult> labels;
+  Circle shape;
+};
+
 struct InferenceResult {
   std::vector<RectanglePrediction> rectangles;
   std::vector<RotatedRectanglePrediction> rotated_rectangles;
   std::vector<PolygonPrediction> polygons;
   std::vector<SaliencyMap> saliency_maps;
+  std::vector<CirclePrediction> circles;
   cv::Rect roi;
 };
 }  // namespace geti

--- a/mediapipe/calculators/geti/utils/detection_classification_combiner_calculator.cc
+++ b/mediapipe/calculators/geti/utils/detection_classification_combiner_calculator.cc
@@ -1,19 +1,3 @@
-//
-//  INTEL CONFIDENTIAL
-//
-//  Copyright (C) 2023 Intel Corporation
-//
-//  This software and the related documents are Intel copyrighted materials, and
-// your use of them is governed by the express license under which they were
-// provided to you ("License"). Unless the License provides otherwise, you may
-// not use, modify, copy, publish, distribute, disclose or transmit this
-// software or the related documents without Intel's prior written permission.
-//
-//  This software and the related documents are provided as is, with no express
-// or implied warranties, other than those that are expressly stated in the
-// License.
-//
-
 #include "detection_classification_combiner_calculator.h"
 
 #include "../inference/utils.h"

--- a/mediapipe/calculators/geti/utils/detection_classification_combiner_calculator.h
+++ b/mediapipe/calculators/geti/utils/detection_classification_combiner_calculator.h
@@ -1,18 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
 #ifndef DETECTION_CLASSIFICATION_COMBINER_CALCULATOR_H_
 #define DETECTION_CLASSIFICATION_COMBINER_CALCULATOR_H_
 

--- a/mediapipe/calculators/geti/utils/detection_classification_result_calculator.h
+++ b/mediapipe/calculators/geti/utils/detection_classification_result_calculator.h
@@ -1,18 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
 #ifndef DETECTION_CLASSIFICATION_RESULT_CALCULATOR_H_
 #define DETECTION_CLASSIFICATION_RESULT_CALCULATOR_H_
 

--- a/mediapipe/calculators/geti/utils/detection_extraction_calculator.cc
+++ b/mediapipe/calculators/geti/utils/detection_extraction_calculator.cc
@@ -1,19 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
-
 #include "detection_extraction_calculator.h"
 
 #include <memory>

--- a/mediapipe/calculators/geti/utils/detection_extraction_calculator.h
+++ b/mediapipe/calculators/geti/utils/detection_extraction_calculator.h
@@ -1,18 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
 #ifndef DETECTION_EXTRACTION_CALCULATOR_H_
 #define DETECTION_EXTRACTION_CALCULATOR_H_
 

--- a/mediapipe/calculators/geti/utils/detection_segmentation_combiner_calculator.h
+++ b/mediapipe/calculators/geti/utils/detection_segmentation_combiner_calculator.h
@@ -1,18 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
 #ifndef DETECTION_SEGMENTATION_COMBINER_CALCULATOR_H_
 #define DETECTION_SEGMENTATION_COMBINER_CALCULATOR_H_
 

--- a/mediapipe/calculators/geti/utils/detection_segmentation_result_calculator.h
+++ b/mediapipe/calculators/geti/utils/detection_segmentation_result_calculator.h
@@ -1,18 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
 #ifndef DETECTION_SEGMENTATION_RESULT_CALCULATOR_H_
 #define DETECTION_SEGMENTATION_RESULT_CALCULATOR_H_
 

--- a/mediapipe/calculators/geti/utils/emptylabel_calculator.cc
+++ b/mediapipe/calculators/geti/utils/emptylabel_calculator.cc
@@ -1,23 +1,6 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
-
-#include "emptylabel_calculator.h"
-
 #include <memory>
 
+#include "emptylabel_calculator.h"
 #include "data_structures.h"
 
 namespace mediapipe {
@@ -40,6 +23,7 @@ absl::Status EmptyLabelCalculator::GetiProcess(CalculatorContext *cc) {
   auto prediction = cc->Inputs().Tag("PREDICTION").Get<geti::InferenceResult>();
   size_t n_predictions = prediction.polygons.size() +
                          prediction.rectangles.size() +
+                         prediction.circles.size() +
                          prediction.rotated_rectangles.size();
   if (n_predictions == 0) {
     const auto &options = cc->Options<EmptyLabelOptions>();

--- a/mediapipe/calculators/geti/utils/emptylabel_calculator.h
+++ b/mediapipe/calculators/geti/utils/emptylabel_calculator.h
@@ -1,19 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
-
 #ifndef EMPTYLABEL_CALCULATOR_H_
 #define EMPTYLABEL_CALCULATOR_H_
 

--- a/mediapipe/calculators/geti/utils/emptylabel_calculator_test.cc
+++ b/mediapipe/calculators/geti/utils/emptylabel_calculator_test.cc
@@ -1,19 +1,3 @@
-//
-//  INTEL CONFIDENTIAL
-//
-//  Copyright (C) 2023 Intel Corporation
-//
-//  This software and the related documents are Intel copyrighted materials, and
-// your use of them is governed by the express license under which they were
-// provided to you ("License"). Unless the License provides otherwise, you may
-// not use, modify, copy, publish, distribute, disclose or transmit this
-// software or the related documents without Intel's prior written permission.
-//
-//  This software and the related documents are provided as is, with no express
-// or implied warranties, other than those that are expressly stated in the
-// License.
-//
-
 #include "../inference/test_utils.h"
 #include "mediapipe/framework/calculator_framework.h"
 #include "mediapipe/framework/calculator_runner.h"

--- a/mediapipe/calculators/geti/utils/loop_calculators.cc
+++ b/mediapipe/calculators/geti/utils/loop_calculators.cc
@@ -1,19 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
-
 #include "../utils/loop_calculators.h"
 
 namespace mediapipe {

--- a/mediapipe/calculators/geti/utils/loop_calculators.h
+++ b/mediapipe/calculators/geti/utils/loop_calculators.h
@@ -1,25 +1,10 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
 #ifndef LOOP_CALCULATORS_H
 #define LOOP_CALCULATORS_H
 
+#include <vector>
+
 #include <models/input_data.h>
 #include <models/results.h>
-
-#include <vector>
 
 #include "../inference/geti_calculator_base.h"
 #include "mediapipe/calculators/core/begin_loop_calculator.h"

--- a/mediapipe/calculators/geti/utils/overlay_calculator.cc
+++ b/mediapipe/calculators/geti/utils/overlay_calculator.cc
@@ -1,18 +1,3 @@
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
 #include "overlay_calculator.h"
 
 namespace mediapipe {

--- a/mediapipe/calculators/geti/utils/overlay_calculator.h
+++ b/mediapipe/calculators/geti/utils/overlay_calculator.h
@@ -1,19 +1,3 @@
-
-/**
- *  INTEL CONFIDENTIAL
- *
- *  Copyright (C) 2023 Intel Corporation
- *
- *  This software and the related documents are Intel copyrighted materials, and
- * your use of them is governed by the express license under which they were
- * provided to you ("License"). Unless the License provides otherwise, you may
- * not use, modify, copy, publish, distribute, disclose or transmit this
- * software or the related documents without Intel's prior written permission.
- *
- *  This software and the related documents are provided as is, with no express
- * or implied warranties, other than those that are expressly stated in the
- * License.
- */
 #ifndef OVERLAY_CALCULATOR_H
 #define OVERLAY_CALCULATOR_H
 


### PR DESCRIPTION
1. Implement the changes to the geti calculators since feb.
2. Clean up (mostly removing some leftovers)
3. Fixed issue (that would've been copied over): instance segmentation had an improvement contourer. However that contourer was upscaling wrong. Improved the code there so that it is still faster than model api, but better quality than previously (inside geti repo).