### PR TITLE
Windows mediapipe

### DIFF
--- a/Dockerfile.openvino
+++ b/Dockerfile.openvino
@@ -104,7 +104,7 @@ RUN ln -s libOpenCL.so.1 libOpenCL.so
 
 # install ovms_lib requirements
 # xml2, uuid for azure
-RUN apt-get install -y curl libpugixml1v5 libtbb2 libxml2-dev uuid-dev uuid libssl-dev --no-install-recommends
+RUN apt-get update && apt-get install -y curl libpugixml1v5 libtbb2 libxml2-dev uuid-dev uuid libssl-dev --no-install-recommends
 
 RUN apt-get update && apt-get install --no-install-recommends -y libtool
 

--- a/Dockerfile.openvino
+++ b/Dockerfile.openvino
@@ -85,6 +85,23 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     build-essential \
     unzip
 
+# Add Nvidia dev tool if needed
+RUN apt-get update ; \
+apt-get install -y --no-install-recommends opencl-clhpp-headers opencl-c-headers intel-opencl-icd libva-dev&& \
+apt-get clean && rm -rf /var/lib/apt/lists/* && rm -rf /tmp/* ;
+
+ARG INSTALL_DRIVER_VERSION="23.22.26516"
+RUN mkdir /tmp/gpu_deps && cd /tmp/gpu_deps ; \
+        curl -L -O https://github.com/intel/compute-runtime/releases/download/23.22.26516.18/intel-level-zero-gpu_1.3.26516.18_amd64.deb ; \
+        curl -L -O https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.14062.11/intel-igc-core_1.0.14062.11_amd64.deb ; \
+        curl -L -O https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.14062.11/intel-igc-opencl_1.0.14062.11_amd64.deb ; \
+        curl -L -O https://github.com/intel/compute-runtime/releases/download/23.22.26516.18/intel-opencl-icd_23.22.26516.18_amd64.deb ; \
+        curl -L -O https://github.com/intel/compute-runtime/releases/download/23.22.26516.18/libigdgmm12_22.3.0_amd64.deb ; \
+        dpkg -i *.deb && rm -Rf /tmp/gpu_deps ;
+
+WORKDIR /usr/lib/x86_64-linux-gnu/
+RUN ln -s libOpenCL.so.1 libOpenCL.so
+
 # install ovms_lib requirements
 # xml2, uuid for azure
 RUN apt-get install -y curl libpugixml1v5 libtbb2 libxml2-dev uuid-dev uuid libssl-dev --no-install-recommends

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -718,9 +718,15 @@ new_local_repository(
 # Boost (needed for Azure Storage SDK)
 
 new_local_repository(
-    name = "boost",
+    name = "linux_boost",
     path = "/usr/local/lib/",
     build_file = "@ovms//third_party/boost:BUILD"
+)
+
+new_local_repository(
+    name = "windows_boost",
+    path = "C:\\local\\boost_1_69_0",
+    build_file = "@ovms//third_party/boost:boost_windows.BUILD"
 )
 
 # Google Cloud SDK

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -376,7 +376,7 @@ new_local_repository(
 new_local_repository(
     name = "windows_opencv",
     build_file = "@//third_party:opencv_windows.BUILD",
-    path = "C:\\opencv\\build",
+    path = "C:\\opt\\opencv\\build",
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -192,6 +192,7 @@ http_archive(
         "https://github.com/google/glog/archive/3a0d4d22c5ae0b9a2216988411cfa6bf860cc372.zip",
     ],
 )
+
 http_archive(
     name = "com_github_glog_glog_no_gflags",
     strip_prefix = "glog-3a0d4d22c5ae0b9a2216988411cfa6bf860cc372",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -635,7 +635,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "ovms",
     remote = "https://github.com/openvinotoolkit/model_server",
-    commit = "f958bf8a1b59c5ad45bef54657e523f99fa0891f", # ov 2024.4 (#2681)
+    commit = "92c1cbb64ddae29b11c90d30dcec1579c464ec61" # windows3
 )
 
 # DEV ovms - adjust local repository path for build

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -845,3 +845,15 @@ git_repository(
     remote = "https://github.com/nlohmann/json/",
     tag = "v3.11.3",
 )
+
+new_local_repository(
+    name = "windows_opencl",
+    build_file = "@ovms//third_party/opencl:opencl_windows.BUILD",
+    path = "C:\\opt\\opencl\\external\\OpenCL-CLHPP",
+)
+
+new_local_repository(
+    name = "windows_opencl2",
+    build_file = "@ovms//third_party/opencl:opencl_windows2.BUILD",
+    path = "C:\\opt\\opencl\\external\\OpenCL-Headers",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -816,6 +816,12 @@ new_local_repository(
     path = "/opt/intel/openvino/runtime",
 )
 
+new_local_repository(
+    name = "windows_openvino",
+    build_file = "@ovms//third_party/openvino:openvino_windows.BUILD",
+    path = "C:\\opt\\intel\\openvino_2024\\runtime",
+)
+
 git_repository(
     name = "oneTBB",
     branch = "v2021.10.0",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -636,7 +636,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "ovms",
     remote = "https://github.com/openvinotoolkit/model_server",
-    commit = "92c1cbb64ddae29b11c90d30dcec1579c464ec61" # windows3
+    commit = "ba43198285a1bbad7ec74b672161eb84d27e6adf" # Windows groovy (#2762)
 )
 
 # DEV ovms - adjust local repository path for build

--- a/docs/development.md
+++ b/docs/development.md
@@ -65,8 +65,8 @@ Example file contents for specific datatype is as follows:
 
 The supported ov:Tensor datatypes for dumping to file are:
 ```bash
-    TYPE_CASE(ov::element::Type_t::f64, _Float64)
-    TYPE_CASE(ov::element::Type_t::f32, _Float32)
+    TYPE_CASE(ov::element::Type_t::f64, double)
+    TYPE_CASE(ov::element::Type_t::f32, float)
     TYPE_CASE(ov::element::Type_t::i64, int64_t)
     TYPE_CASE(ov::element::Type_t::i32, int32_t)
     TYPE_CASE(ov::element::Type_t::i16, int16_t)

--- a/mediapipe/calculators/openvino/BUILD
+++ b/mediapipe/calculators/openvino/BUILD
@@ -70,7 +70,7 @@ cc_library(
         "//mediapipe/framework/port:ret_check",
         "//mediapipe/framework/stream_handler:fixed_size_input_stream_handler",
         "//mediapipe/util:resource_util",
-        "@linux_openvino//:openvino",
+        "//third_party:openvino",
     ],
     alwayslink = 1,
 )
@@ -84,7 +84,7 @@ cc_library(
     #    ]),
     visibility = ["//visibility:public"],
     deps = [
-        "@linux_openvino//:openvino",
+        "//third_party:openvino",
     ],
 )
 
@@ -108,7 +108,7 @@ cc_library(
         "//mediapipe/framework/port:ret_check",
         "//mediapipe/framework/port:map_util",
         "//mediapipe/framework:packet",
-        "@linux_openvino//:openvino",
+        "//third_party:openvino",
     ] + select({
         "//conditions:default": [
         ],
@@ -130,7 +130,7 @@ cc_library(
         "//mediapipe/framework/formats:location",
         "//mediapipe/framework/port:ret_check",
         "//mediapipe/util:resource_util",
-        "@linux_openvino//:openvino",
+        "//third_party:openvino",
     ] + select({
         "//mediapipe:android": [
             "//mediapipe/util/android/file/base",
@@ -176,7 +176,7 @@ cc_library(
         "//mediapipe/framework/formats:location",
         "//mediapipe/framework/formats/object_detection:anchor_cc_proto",
         "//mediapipe/framework/port:ret_check",
-        "@linux_openvino//:openvino",
+        "//third_party:openvino",
     ],
     alwayslink = 1,
 )

--- a/mediapipe/calculators/ovms/BUILD
+++ b/mediapipe/calculators/ovms/BUILD
@@ -36,7 +36,6 @@ cc_library(
     copts = ["-Iexternal/ovms/src","-Isrc"],
     linkopts = ["-Lmediapipe/"],
     alwayslink = 1,
-    linkstatic = True,
 )
 
 cc_library(
@@ -55,7 +54,6 @@ cc_library(
         "//third_party:openvino",
     ],
     copts = ["-Iexternal/ovms/src","-Isrc"],
-    alwayslink = 1,
 )
 
 cc_library(

--- a/mediapipe/calculators/ovms/BUILD
+++ b/mediapipe/calculators/ovms/BUILD
@@ -51,7 +51,7 @@ cc_library(
         "//mediapipe/framework/port:logging",
         "@ovms//src:ovms_header",
         "@model_api//:model_api",
-        "@linux_openvino//:openvino",
+        "//third_party:openvino",
     ],
     copts = ["-Iexternal/ovms/src","-Isrc"],
 )
@@ -80,7 +80,7 @@ cc_library(
         "openvinoinferencedumputils.h"
     ],
     deps = [ 
-        "@linux_openvino//:openvino",
+        "//third_party:openvino",
     ],
     alwayslink = 1,
 )
@@ -116,7 +116,7 @@ cc_library(
         ":openvinoinferencecalculator_cc_proto",
         "//mediapipe/framework:calculator_framework",
         "//mediapipe/framework/formats:tensor", # Tensor GetContract
-        "@linux_openvino//:openvino",
+        "//third_party:openvino",
         "@org_tensorflow//tensorflow/core:framework",
         "@org_tensorflow//tensorflow/lite/c:c_api",
         "@ovms//src:ovms_header",
@@ -138,7 +138,7 @@ cc_library(
         ":openvinoinferenceutils",
         ":openvinomodelserversessioncalculator_cc_proto",
         "//mediapipe/framework:calculator_framework",
-        "@linux_openvino//:openvino",
+        "//third_party:openvino",
         "@ovms//src:ovms_header",
     ],
     copts = ["-Iexternal/ovms/src","-Isrc"],

--- a/mediapipe/calculators/ovms/BUILD
+++ b/mediapipe/calculators/ovms/BUILD
@@ -36,6 +36,7 @@ cc_library(
     copts = ["-Iexternal/ovms/src","-Isrc"],
     linkopts = ["-Lmediapipe/"],
     alwayslink = 1,
+    linkstatic = True,
 )
 
 cc_library(
@@ -54,6 +55,7 @@ cc_library(
         "//third_party:openvino",
     ],
     copts = ["-Iexternal/ovms/src","-Isrc"],
+    alwayslink = 1,
 )
 
 cc_library(

--- a/mediapipe/calculators/ovms/modelapiovmsadapter.cc
+++ b/mediapipe/calculators/ovms/modelapiovmsadapter.cc
@@ -34,56 +34,24 @@
 #pragma GCC diagnostic pop
 // here we need to decide if we have several calculators (1 for OVMS repository, 1-N inside mediapipe)
 // for the one inside OVMS repo it makes sense to reuse code from ovms lib
-namespace mediapipe {
-
+namespace mediapipe::ovms {
+    
 using std::endl;
-
-
-#define THROW_IF_CIRCULAR_ERR(C_API_CALL)                                       \
-    {                                                                           \
-        auto* fatalErr = C_API_CALL;                                            \
-        if (fatalErr != nullptr) {                                              \
-            std::runtime_error exc("Getting status details circular error");    \
-            throw exc;                                                          \
-        }                                                                       \ 
-    }
-
-#define ASSERT_CAPI_STATUS_NULL(C_API_CALL)                                                 \
-    {                                                                                       \
-        auto* err = C_API_CALL;                                                             \
-        if (err != nullptr) {                                                               \
-            uint32_t code = 0;                                                              \
-            const char* msg = nullptr;                                                      \
-            THROW_IF_CIRCULAR_ERR(OVMS_StatusCode(err, &code));                             \
-            THROW_IF_CIRCULAR_ERR(OVMS_StatusDetails(err, &msg));                           \
-            LOG(INFO) << "Error encountred in OVMSCalculator:" << msg << " code: " << code; \
-            std::runtime_error exc(msg);                                                    \
-            OVMS_StatusDelete(err);                                                         \
-            throw exc;                                                                      \
-        }                                                                                   \
-    }
-#define CREATE_GUARD(GUARD_NAME, CAPI_TYPE, CAPI_PTR) \
-    std::unique_ptr<CAPI_TYPE, decltype(&(CAPI_TYPE##Delete))> GUARD_NAME(CAPI_PTR, &(CAPI_TYPE##Delete));
-
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
 using InferenceOutput = std::map<std::string, ov::Tensor>;
 using InferenceInput = std::map<std::string, ov::Tensor>;
 
-namespace ovms {
+#define THROW_IF_CIRCULAR_ERR(C_API_CALL)
+
+#define ASSERT_CAPI_STATUS_NULL(C_API_CALL)
+
+#define CREATE_GUARD(GUARD_NAME, CAPI_TYPE, CAPI_PTR) \
+    std::unique_ptr<CAPI_TYPE, decltype(&(CAPI_TYPE##Delete))> GUARD_NAME(CAPI_PTR, &(CAPI_TYPE##Delete));
+
 static OVMS_DataType OVPrecision2CAPI(ov::element::Type_t datatype);
 static ov::element::Type_t CAPI2OVPrecision(OVMS_DataType datatype);
 static ov::Tensor makeOvTensor(OVMS_DataType datatype, const int64_t* shape, size_t dimCount, const void* voutputData, size_t bytesize);
-
-OVMSInferenceAdapter::OVMSInferenceAdapter(const std::string& servableName, uint32_t servableVersion, OVMS_Server* cserver) :
-    servableName(servableName),
-    servableVersion(servableVersion) {
-    if (nullptr != cserver) {
-        this->cserver = cserver;
-    } else {
-        OVMS_ServerNew(&this->cserver);
-    }
-}
 
 OVMSInferenceAdapter::~OVMSInferenceAdapter() {
     LOG(INFO) << "OVMSAdapter destr";
@@ -326,5 +294,4 @@ static ov::Tensor makeOvTensor(OVMS_DataType datatype, const int64_t* shape, siz
 }
 
 #pragma GCC diagnostic pop
-}  // namespace ovms
-}  // namespace mediapipe
+}  // namespace mediapipe::ovms

--- a/mediapipe/calculators/ovms/modelapiovmsadapter.hpp
+++ b/mediapipe/calculators/ovms/modelapiovmsadapter.hpp
@@ -26,13 +26,15 @@
 #include <adapters/inference_adapter.h>  // model_api/model_api/cpp/adapters/include/adapters/inference_adapter.h
 #include <openvino/openvino.hpp>
 
+#include "ovms.h"  // NOLINT
+
 // here we need to decide if we have several calculators (1 for OVMS repository, 1-N inside mediapipe)
 // for the one inside OVMS repo it makes sense to reuse code from ovms lib
 
 class OVMS_Server_;
 typedef struct OVMS_Server_ OVMS_Server;
-namespace mediapipe {
-namespace ovms {
+
+namespace mediapipe::ovms {
 
 using InferenceOutput = std::map<std::string, ov::Tensor>;
 using InferenceInput = std::map<std::string, ov::Tensor>;
@@ -50,7 +52,15 @@ class OVMSInferenceAdapter : public ::InferenceAdapter {
     ov::AnyMap modelConfig;
 
 public:
-    OVMSInferenceAdapter(const std::string& servableName, uint32_t servableVersion = 0, OVMS_Server* server = nullptr);
+    OVMSInferenceAdapter(const std::string& servableName, uint32_t servableVersion = 0, OVMS_Server* server = nullptr) :
+        servableName(servableName),
+        servableVersion(servableVersion) {
+        if (nullptr != cserver) {
+            this->cserver = cserver;
+        } else {
+            OVMS_ServerNew(&this->cserver);
+        }
+    }
     virtual ~OVMSInferenceAdapter();
     InferenceOutput infer(const InferenceInput& input) override;
     void loadModel(const std::shared_ptr<const ov::Model>& model, ov::Core& core,
@@ -66,5 +76,4 @@ public:
     std::vector<std::string> getOutputNames() const override;
     const ov::AnyMap& getModelConfig() const override;
 };
-}  // namespace ovms
 }  // namespace mediapipe

--- a/mediapipe/calculators/ovms/modelapiovmsadapter.hpp
+++ b/mediapipe/calculators/ovms/modelapiovmsadapter.hpp
@@ -52,6 +52,7 @@ class OVMSInferenceAdapter : public ::InferenceAdapter {
     ov::AnyMap modelConfig;
 
 public:
+    // TODO Windows: Fix definition in header - does not compile in cpp.
     OVMSInferenceAdapter(const std::string& servableName, uint32_t servableVersion = 0, OVMS_Server* server = nullptr) :
         servableName(servableName),
         servableVersion(servableVersion) {

--- a/mediapipe/calculators/ovms/openvinoinferencecalculator.cc
+++ b/mediapipe/calculators/ovms/openvinoinferencecalculator.cc
@@ -48,32 +48,6 @@
 namespace mediapipe {
 using std::endl;
 
-namespace {
-
-#define ASSERT_CIRCULAR_ERR(C_API_CALL) \
-    {                                   \
-        auto* fatalErr = C_API_CALL;    \
-        RET_CHECK(fatalErr == nullptr); \
-    }
-
-#define ASSERT_CAPI_STATUS_NULL(C_API_CALL)                                                 \
-    {                                                                                       \
-        auto* err = C_API_CALL;                                                             \
-        if (err != nullptr) {                                                               \
-            uint32_t code = 0;                                                              \
-            const char* msg = nullptr;                                                      \
-            ASSERT_CIRCULAR_ERR(OVMS_StatusCode(err, &code));                               \
-            ASSERT_CIRCULAR_ERR(OVMS_StatusDetails(err, &msg));                             \
-            LOG(INFO) << "Error encountred in OVMSCalculator:" << msg << " code: " << code; \
-            OVMS_StatusDelete(err);                                                         \
-            RET_CHECK(err == nullptr);                                                      \
-        }                                                                                   \
-    }
-#define CREATE_GUARD(GUARD_NAME, CAPI_TYPE, CAPI_PTR) \
-    std::unique_ptr<CAPI_TYPE, decltype(&(CAPI_TYPE##Delete))> GUARD_NAME(CAPI_PTR, &(CAPI_TYPE##Delete));
-
-}  // namespace
-
 using TFSDataType = tensorflow::DataType;
 
 TFSDataType getPrecisionAsDataType(ov::element::Type_t precision) {

--- a/mediapipe/calculators/ovms/openvinoinferencedumputils.cc
+++ b/mediapipe/calculators/ovms/openvinoinferencedumputils.cc
@@ -44,8 +44,8 @@ using InferenceInput = std::map<std::string, ov::Tensor>;
 static std::stringstream dumpOvTensor(const ov::Tensor& tensor) {
     std::stringstream dumpStream;
     switch (tensor.get_element_type()) {
-        TYPE_CASE(ov::element::Type_t::f64, _Float64)
-        TYPE_CASE(ov::element::Type_t::f32, _Float32)
+        TYPE_CASE(ov::element::Type_t::f64, double)
+        TYPE_CASE(ov::element::Type_t::f32, float)
         TYPE_CASE(ov::element::Type_t::i64, int64_t)
         TYPE_CASE(ov::element::Type_t::i32, int32_t)
         TYPE_CASE(ov::element::Type_t::i16, int16_t)

--- a/mediapipe/calculators/ovms/openvinomodelserversessioncalculator.h
+++ b/mediapipe/calculators/ovms/openvinomodelserversessioncalculator.h
@@ -33,8 +33,6 @@
 #pragma GCC diagnostic pop
 namespace mediapipe {
 
-using ovms::OVMSInferenceAdapter;
-
 class OpenVINOModelServerSessionCalculator : public CalculatorBase {
     std::shared_ptr<::InferenceAdapter> adapter;
     std::unordered_map<std::string, std::string> outputNameToTag;

--- a/mediapipe/modules/hand_landmark/hand_landmark_cpu.pbtxt
+++ b/mediapipe/modules/hand_landmark/hand_landmark_cpu.pbtxt
@@ -164,7 +164,7 @@ node {
   options: {
     [mediapipe.TensorsToClassificationCalculatorOptions.ext] {
       top_k: 1
-      label_map_path: "/mediapipe/mediapipe/modules/hand_landmark/handedness.txt"
+      label_map_path: "mediapipe/modules/hand_landmark/handedness.txt"
       binary_classification: true
     }
   }

--- a/mediapipe/modules/hand_landmark/hand_landmark_gpu.pbtxt
+++ b/mediapipe/modules/hand_landmark/hand_landmark_gpu.pbtxt
@@ -130,7 +130,7 @@ node {
   options: {
     [mediapipe.TensorsToClassificationCalculatorOptions.ext] {
       top_k: 1
-      label_map_path: "/mediapipe/mediapipe/modules/hand_landmark/handedness.txt"
+      label_map_path: "mediapipe/modules/hand_landmark/handedness.txt"
       binary_classification: true
     }
   }

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -258,6 +258,15 @@ alias(
     }),
 )
 
+alias(
+    name = "openvino",
+    actual = select({
+        "//mediapipe:windows": "@windows_openvino//:openvino",
+        "//conditions:default": "@linux_openvino//:openvino",
+    }),
+    visibility = ["//visibility:public"],
+)
+
 cc_library(
     name = "libffmpeg",
     visibility = ["//visibility:public"],

--- a/third_party/model_api/model_api.bzl
+++ b/third_party/model_api/model_api.bzl
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 def _is_windows(ctx):
     return ctx.os.name.lower().find("windows") != -1
 
@@ -63,48 +64,48 @@ cc_library(
 
 def _get_linux_build_file():
     build_file_content = """
-    load("@rules_foreign_cc//foreign_cc:cmake.bzl", "cmake")
+load("@rules_foreign_cc//foreign_cc:cmake.bzl", "cmake")
 
-    visibility = ["//visibility:public"]
+visibility = ["//visibility:public"]
 
-    filegroup(
-        name = "all_srcs",
-        srcs = glob(["model_api/cpp/**"]),
-        visibility = ["//visibility:public"],
-    )
+filegroup(
+    name = "all_srcs",
+    srcs = glob(["model_api/cpp/**"]),
+    visibility = ["//visibility:public"],
+)
 
-    cmake(
-        name = "model_api_cmake",
-        build_args = [
-            "--verbose",
-            "--",  # <- Pass remaining options to the native tool.
-            # https://github.com/bazelbuild/rules_foreign_cc/issues/329
-            # there is no elegant paralell compilation support
-            "VERBOSE=1",
-            "-j 24",
-        ],
-        cache_entries = {{
-            "CMAKE_POSITION_INDEPENDENT_CODE": "ON",
-            "OpenVINO_DIR": "/opt/intel/openvino/runtime/cmake",
-        }},
-        env = {{
-            "HTTP_PROXY": "{http_proxy}",
-            "HTTPS_PROXY": "{https_proxy}",
-        }},
-        lib_source = ":all_srcs",
-        out_static_libs = ["libmodel_api.a"],
-        tags = ["requires-network"],
-    )
+cmake(
+    name = "model_api_cmake",
+    build_args = [
+        "--verbose",
+        "--",  # <- Pass remaining options to the native tool.
+        # https://github.com/bazelbuild/rules_foreign_cc/issues/329
+        # there is no elegant paralell compilation support
+        "VERBOSE=1",
+        "-j 24",
+    ],
+    cache_entries = {{
+        "CMAKE_POSITION_INDEPENDENT_CODE": "ON",
+        "OpenVINO_DIR": "/opt/intel/openvino/runtime/cmake",
+    }},
+    env = {{
+        "HTTP_PROXY": "{http_proxy}",
+        "HTTPS_PROXY": "{https_proxy}",
+    }},
+    lib_source = ":all_srcs",
+    out_static_libs = ["libmodel_api.a"],
+    tags = ["requires-network"],
+)
 
-    cc_library(
-        name = "model_api",
-        deps = [
-            "@mediapipe//mediapipe/framework/port:opencv_core",
-            "@mediapipe//third_party:openvino",
-            ":model_api_cmake",
-        ],
-        visibility = ["//visibility:public"],
-    )"""
+cc_library(
+    name = "model_api",
+    deps = [
+        "@mediapipe//mediapipe/framework/port:opencv_core",
+        "@mediapipe//third_party:openvino",
+        ":model_api_cmake",
+    ],
+    visibility = ["//visibility:public"],
+)"""
     return build_file_content
 
 def _impl(repository_ctx):

--- a/third_party/model_api/model_api.bzl
+++ b/third_party/model_api/model_api.bzl
@@ -57,7 +57,7 @@ cc_library(
     name = "model_api",
     deps = [
         "@mediapipe//mediapipe/framework/port:opencv_core",
-        "@linux_openvino//:openvino",
+        "@mediapipe//third_party:openvino",
         ":model_api_cmake",
     ],
     visibility = ["//visibility:public"],

--- a/third_party/model_api/model_api.bzl
+++ b/third_party/model_api/model_api.bzl
@@ -13,14 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+def _is_windows(ctx):
+    return ctx.os.name.lower().find("windows") != -1
 
-def _impl(repository_ctx):
-    http_proxy = repository_ctx.os.environ.get("http_proxy", "")
-    https_proxy = repository_ctx.os.environ.get("https_proxy", "")
-    # Note we need to escape '{/}' by doubling them due to call to format
+def _get_windows_build_file():
     build_file_content = """
 load("@rules_foreign_cc//foreign_cc:cmake.bzl", "cmake")
-#load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 
 visibility = ["//visibility:public"]
 
@@ -34,23 +32,20 @@ cmake(
     name = "model_api_cmake",
     build_args = [
         "--verbose",
-        "--",  # <- Pass remaining options to the native tool.
-        # https://github.com/bazelbuild/rules_foreign_cc/issues/329
-        # there is no elegant paralell compilation support
-        "VERBOSE=1",
-        "-j 4",
+        "-j 24",
     ],
     cache_entries = {{
         "CMAKE_POSITION_INDEPENDENT_CODE": "ON",
-        "OpenVINO_DIR": "/opt/intel/openvino/runtime/cmake",
+        "OpenVINO_DIR": "C:/opt/intel/openvino_2024/runtime/cmake",
+        "OpenCV_DIR": "C:/opt/opencv/build",
     }},
     env = {{
         "HTTP_PROXY": "{http_proxy}",
         "HTTPS_PROXY": "{https_proxy}",
     }},
     lib_source = ":all_srcs",
-    out_static_libs = ["libmodel_api.a"],
-    tags = ["requires-network"]
+    out_static_libs = ["model_api.lib"],
+    tags = ["requires-network"],
 )
 
 cc_library(
@@ -62,8 +57,65 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
 )
-
 """
+    
+    return build_file_content
+
+def _get_linux_build_file():
+    build_file_content = """
+    load("@rules_foreign_cc//foreign_cc:cmake.bzl", "cmake")
+
+    visibility = ["//visibility:public"]
+
+    filegroup(
+        name = "all_srcs",
+        srcs = glob(["model_api/cpp/**"]),
+        visibility = ["//visibility:public"],
+    )
+
+    cmake(
+        name = "model_api_cmake",
+        build_args = [
+            "--verbose",
+            "--",  # <- Pass remaining options to the native tool.
+            # https://github.com/bazelbuild/rules_foreign_cc/issues/329
+            # there is no elegant paralell compilation support
+            "VERBOSE=1",
+            "-j 24",
+        ],
+        cache_entries = {{
+            "CMAKE_POSITION_INDEPENDENT_CODE": "ON",
+            "OpenVINO_DIR": "/opt/intel/openvino/runtime/cmake",
+        }},
+        env = {{
+            "HTTP_PROXY": "{http_proxy}",
+            "HTTPS_PROXY": "{https_proxy}",
+        }},
+        lib_source = ":all_srcs",
+        out_static_libs = ["libmodel_api.a"],
+        tags = ["requires-network"],
+    )
+
+    cc_library(
+        name = "model_api",
+        deps = [
+            "@mediapipe//mediapipe/framework/port:opencv_core",
+            "@mediapipe//third_party:openvino",
+            ":model_api_cmake",
+        ],
+        visibility = ["//visibility:public"],
+    )"""
+    return build_file_content
+
+def _impl(repository_ctx):
+    http_proxy = repository_ctx.os.environ.get("HTTP_PROXY", "")
+    https_proxy = repository_ctx.os.environ.get("HTTPS_PROXY", "")
+    # Note we need to escape '{/}' by doubling them due to call to format
+    if _is_windows(repository_ctx):
+        build_file_content = _get_windows_build_file()
+    else:
+        build_file_content = _get_linux_build_file()
+
     repository_ctx.file("BUILD", build_file_content.format(http_proxy=http_proxy, https_proxy=https_proxy))
 
 model_api_repository = repository_rule(

--- a/third_party/opencv_windows.BUILD
+++ b/third_party/opencv_windows.BUILD
@@ -1,7 +1,7 @@
 # Description:
 #   OpenCV libraries for video/image processing on Windows
 #
-# Copyright (c) 2025 Intel Corporation
+# Copyright (c) 2024 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/third_party/opencv_windows.BUILD
+++ b/third_party/opencv_windows.BUILD
@@ -1,11 +1,26 @@
 # Description:
 #   OpenCV libraries for video/image processing on Windows
+#
+# Copyright (c) 2025 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 licenses(["notice"])  # BSD license
 
 exports_files(["LICENSE"])
 
-OPENCV_VERSION = "3410"  # 3.4.10
+OPENCV_VERSION = "470"  # 4.7.0
 
 config_setting(
     name = "opt_build",
@@ -17,19 +32,19 @@ config_setting(
     values = {"compilation_mode": "dbg"},
 )
 
-# The following build rule assumes that the executable "opencv-3.4.10-vc14_vc15.exe"
+# The following build rule assumes that the executable "opencv-4.7.0-windows.exe"
 # is downloaded and the files are extracted to local.
 # If you install OpenCV separately, please modify the build rule accordingly.
 cc_library(
     name = "opencv",
     srcs = select({
         ":opt_build": [
-            "x64/vc15/lib/opencv_world" + OPENCV_VERSION + ".lib",
-            "x64/vc15/bin/opencv_world" + OPENCV_VERSION + ".dll",
+            "x64/vc16/lib/opencv_world" + OPENCV_VERSION + ".lib",
+            "x64/vc16/bin/opencv_world" + OPENCV_VERSION + ".dll",
         ],
         ":dbg_build": [
-            "x64/vc15/lib/opencv_world" + OPENCV_VERSION + "d.lib",
-            "x64/vc15/bin/opencv_world" + OPENCV_VERSION + "d.dll",
+            "x64/vc16/lib/opencv_world" + OPENCV_VERSION + "d.lib",
+            "x64/vc16/bin/opencv_world" + OPENCV_VERSION + "d.dll",
         ],
     }),
     hdrs = glob(["include/opencv2/**/*.h*"]),

--- a/third_party/opencv_windows.BUILD
+++ b/third_party/opencv_windows.BUILD
@@ -20,7 +20,7 @@ licenses(["notice"])  # BSD license
 
 exports_files(["LICENSE"])
 
-OPENCV_VERSION = "470"  # 4.7.0
+OPENCV_VERSION = "4100"  # 4.10.0
 
 config_setting(
     name = "opt_build",

--- a/third_party/opencv_windows.BUILD
+++ b/third_party/opencv_windows.BUILD
@@ -1,20 +1,5 @@
 # Description:
 #   OpenCV libraries for video/image processing on Windows
-#
-# Copyright (c) 2024 Intel Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 
 licenses(["notice"])  # BSD license
 


### PR DESCRIPTION
Making changes required to build ovms on windows:
- Updating opencv version and build
- Removing linux types
- Fixing macro
- Adding model_api windows cmake
- Changing openvino to third_party dependency
- Updating OVMS SHA
- Changing to indirect graph files paths
